### PR TITLE
Burn function used static file location

### DIFF
--- a/pysparc/burn.py
+++ b/pysparc/burn.py
@@ -16,7 +16,7 @@ def print_high_bits(f):
     time.sleep(.01)
     print 'high:', [bin(ord(u)) for u in f.read_data(1)]
 
-def burn():
+def burn(firmware_file):
     global f
     f = Ftdi()
     try:
@@ -43,7 +43,7 @@ def burn():
 
     time.sleep(1)
 
-    with open(os.path.expanduser('/Users/david/Downloads/FPGAConfig_v19.rbf'), 'rb') as file:
+    with open(os.path.expanduser(firmware_file), 'rb') as file:
         while True:
             xbuf = file.read(BUFSIZE)
             if not xbuf:


### PR DESCRIPTION
The burn() function used a static location of the firmware file in David's home folder, which I, frankly, don't have. So now, you need to pass the location of the firmware file to the burn() function.
