### PR TITLE
GPS configuration

### DIFF
--- a/pysparc/config.ini
+++ b/pysparc/config.ini
@@ -1,4 +1,5 @@
 [DAQ]
+force_reset_gps = True
 force_align_adcs = True
 station_name = my_station
 station_number = 0

--- a/pysparc/config.py
+++ b/pysparc/config.py
@@ -1,4 +1,3 @@
-import struct
 import logging
 import ConfigParser
 import weakref

--- a/pysparc/gps_messages.py
+++ b/pysparc/gps_messages.py
@@ -16,7 +16,8 @@ from messages import BaseMessage, MessageError
 logger = logging.getLogger(__name__)
 
 
-msg_ids = {'primary_timing': 0x8fab,
+msg_ids = {'reset': 0x1e,
+           'primary_timing': 0x8fab,
            'supplemental_timing': 0x8fac,
            }
 
@@ -84,6 +85,20 @@ class GPSMessage(BaseMessage):
         else:
             return msg.startswith(struct.pack('>H', cls.identifier))
 
+    def encode(self):
+        """Encode message to bytestream to be sent to the hardware.
+
+        For GPS messages, the identifier may be a byte or a word. If
+        :attr:`msg_format` is the empty string, autodetect the identifier size.
+
+        """
+        if self.msg_format == '':
+            if self.identifier <= 0xff:
+                self.msg_format = 'B'
+            else:
+                self.msg_format = 'H'
+        return super(GPSMessage, self).encode()
+
 
 class PrimaryTimingPacket(GPSMessage):
 
@@ -127,6 +142,11 @@ class SupplementalTimingPacket(GPSMessage):
         return "Supplemental Timing Packet: mode: %d, alarms: %s, " \
                "status: %d" % (self.receiver_mode, bin(self.alarms),
                                self.gps_status)
+
+
+class ResetMessage(GPSMessage):
+
+    identifier = msg_ids['reset']
 
 
 def GPSMessageFactory(buff):

--- a/pysparc/gps_messages.py
+++ b/pysparc/gps_messages.py
@@ -297,4 +297,4 @@ def find_message_class(msg, cls):
     for klass in cls.__subclasses__():
         if klass.is_message_for(msg):
             return klass
-    raise UnknownMessageError("Unknown message: %r" % msg[:5])
+    raise UnknownMessageError("Unknown message: %r" % msg)

--- a/pysparc/gps_messages.py
+++ b/pysparc/gps_messages.py
@@ -11,7 +11,7 @@ import logging
 import re
 from math import degrees, radians
 
-from messages import BaseMessage, MessageError
+from messages import BaseMessage, MessageError, CorruptMessageError
 
 
 logger = logging.getLogger(__name__)
@@ -115,10 +115,13 @@ class PrimaryTimingPacket(GPSMessage):
         self.parse_message(msg)
 
     def parse_message(self, msg):
-        (identifier, self.time_of_week, self.week_number, self.utc_offset,
-         self.timing_flag, self.seconds, self.minutes, self.hours,
-         self.day_of_month, self.month, self.year) = \
-            struct.unpack(self.msg_format, msg)
+        try:
+            (identifier, self.time_of_week, self.week_number, self.utc_offset,
+             self.timing_flag, self.seconds, self.minutes, self.hours,
+             self.day_of_month, self.month, self.year) = \
+                struct.unpack(self.msg_format, msg)
+        except struct.error:
+            raise CorruptMessageError("Error unpacking message: %r" % msg)
 
     def __str__(self):
         return 'Primary Timing Packet: %d-%d-%d %d:%02d:%02d' % (
@@ -136,11 +139,14 @@ class SupplementalTimingPacket(GPSMessage):
         self.parse_message(msg)
 
     def parse_message(self, msg):
-        (identifier, self.receiver_mode, x1, self.survey_progress, x2, x3,
-         self.alarms, self.gps_status, x4, spare1, spare2, self.clock_bias,
-         self.clock_bias_rate, x5, x6, self.temperature, self.latitude,
-         self.longitude, self.altitude, self.pps_quantization_error, spare3) =\
-            struct.unpack(self.msg_format, msg)
+        try:
+            (identifier, self.receiver_mode, x1, self.survey_progress, x2, x3,
+             self.alarms, self.gps_status, x4, spare1, spare2, self.clock_bias,
+             self.clock_bias_rate, x5, x6, self.temperature, self.latitude,
+             self.longitude, self.altitude, self.pps_quantization_error,
+             spare3) = struct.unpack(self.msg_format, msg)
+        except struct.error:
+            raise CorruptMessageError("Error unpacking message: %r" % msg)
 
         self.latitude = degrees(self.latitude)
         self.longitude = degrees(self.longitude)
@@ -211,11 +217,14 @@ class SoftwareVersionMessage(GPSMessage):
         self.parse_message(msg)
 
     def parse_message(self, msg):
-        (identifier, self.version_major, self.version_minor,
-         self.version_month,  self.version_day,  self.version_year,
-         self.revision_major,  self.revision_minor, self.revision_month,
-         self.revision_day,  self.revision_year) = \
-            struct.unpack(self.msg_format, msg)
+        try:
+            (identifier, self.version_major, self.version_minor,
+             self.version_month, self.version_day, self.version_year,
+             self.revision_major, self.revision_minor, self.revision_month,
+             self.revision_day, self.revision_year) = \
+                struct.unpack(self.msg_format, msg)
+        except struct.error:
+            raise CorruptMessageError("Error unpacking message: %r" % msg)
 
     def __str__(self):
         return "Firmware version: %d.%d. GPS revision: %d.%d" % \

--- a/pysparc/gps_messages.py
+++ b/pysparc/gps_messages.py
@@ -274,7 +274,11 @@ def GPSMessageFactory(buff):
             logger.error(e)
             return None
         else:
-            return klass(msg)
+            try:
+                return klass(msg)
+            except CorruptMessageError as exc:
+                logger.error(exc)
+                return None
     else:
         return None
 

--- a/pysparc/gps_messages.py
+++ b/pysparc/gps_messages.py
@@ -153,6 +153,23 @@ class SupplementalTimingPacket(GPSMessage):
 
 class ResetMessage(GPSMessage):
 
+    """Reset the Trimble GPS hardware.
+
+    There are four different reset modes; this message implements three of
+    them: warm, cold and factory reset. A warm reset will clear the RAM but
+    keep all GPS data. A cold reset (equivalent to a power cycle) will clear
+    the RAM including the GPS data. The data is read back to RAM from the flash
+    ROM. A factory reset will clear the RAM, *and* the flash ROM.
+
+    Interestingly, once the reset is complete, the cold reset appears to have
+    kept the GPS location, but not the GPS time. That is set to 1999-8-22. In
+    contrast, the factory reset appears to have reset the GPS location (it is
+    set to 0., 0., 0.) but the GPS time is retained.
+
+    :param reset_mode: either 'warm', 'cold', or 'factory' (default).
+
+    """
+
     identifier = msg_ids['reset']
     msg_format = 'BB'
 

--- a/pysparc/hardware.py
+++ b/pysparc/hardware.py
@@ -24,6 +24,7 @@ import ftdi_chip
 from ftdi_chip import FtdiChip
 from messages import (HisparcMessageFactory, ResetMessage,
                       InitializeMessage, MeasuredDataMessage)
+import gps_messages
 from gps_messages import GPSMessageFactory
 import config
 
@@ -323,3 +324,8 @@ class TrimbleGPS(BaseHardware):
         """
         self.read_into_buffer()
         return GPSMessageFactory(self._buffer)
+
+    def reset_defaults(self):
+        """Reset GPS factory defaults."""
+
+        self.send_message(gps_messages.ResetMessage(reset_mode='factory'))

--- a/pysparc/hardware.py
+++ b/pysparc/hardware.py
@@ -326,6 +326,12 @@ class TrimbleGPS(BaseHardware):
         return GPSMessageFactory(self._buffer)
 
     def reset_defaults(self):
-        """Reset GPS factory defaults."""
+        """Reset GPS defaults.
+
+        First, the Trimble GPS unit is reset to factory settings. Then, the
+        survey length is set to a full day.
+
+        """
 
         self.send_message(gps_messages.ResetMessage(reset_mode='factory'))
+        self.send_message(gps_messages.SetSurveyParameters(num_fixes=86400))

--- a/pysparc/hardware.py
+++ b/pysparc/hardware.py
@@ -19,7 +19,6 @@ Contents
 
 import logging
 import time
-import random
 
 import ftdi_chip
 from ftdi_chip import FtdiChip

--- a/pysparc/monitor.py
+++ b/pysparc/monitor.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 MONITOR_URL = 'http://vpn.hisparc.nl/cgi-bin/cmd.cgi'
+# FIXME: the following is not DRY
 STATUS_MSG = {0: 'OK', 1: 'WARNING', 2: 'CRITICAL', 3: 'UNKNOWN'}
 OK = 0
 WARNING = 1
@@ -110,6 +111,8 @@ class Monitor(object):
         (UNKNOWN).
 
         """
+        # the parameters, especially the values 2 and 30, were determined by
+        # reverse-engineering the communication protocol
         payload = {'cmd_mod': '2',  'cmd_typ': '30',  'host': self.host,
                    'plugin_output': msg,  'plugin_state': status,
                    'service': service}

--- a/pysparc/tests/test_config.py
+++ b/pysparc/tests/test_config.py
@@ -1,7 +1,7 @@
 import unittest
 import weakref
 
-from mock import patch, sentinel, Mock, MagicMock, mock_open, call, ANY
+from mock import patch, sentinel, Mock, MagicMock, call, ANY
 
 import pysparc.config
 
@@ -127,7 +127,8 @@ class ReadWriteConfigTest(unittest.TestCase):
 
     @patch.object(pysparc.config.Config, '__setattr__')
     @patch.object(pysparc.config, 'literal_eval')
-    def test_read_config_gets_all_members_except_device(self, mock_eval, mock_setattr):
+    def test_read_config_gets_all_members_except_device(self, mock_eval,
+                                                        mock_setattr):
         eval_value = mock_eval.return_value
 
         mock_configparser = Mock()
@@ -170,8 +171,8 @@ class WriteSettingTest(unittest.TestCase):
 
     def test_write_byte_setting_to_device_calls_map_setting(self):
         self.config._write_byte_setting_to_device(self.mock_setting)
-        self.mock_map_setting.assert_called_once_with(sentinel.value,
-            sentinel.low, sentinel.high, 0x00, 0xff)
+        self.mock_map_setting.assert_called_once_with(
+            sentinel.value, sentinel.low, sentinel.high, 0x00, 0xff)
 
     def test_write_byte_setting_to_device_creates_message(self):
         self.config._write_byte_setting_to_device(self.mock_setting)

--- a/pysparc/tests/test_gps_messages.py
+++ b/pysparc/tests/test_gps_messages.py
@@ -152,7 +152,7 @@ class GPSMessageFactoryTest(unittest.TestCase):
             sentinel.msg
         gps_messages.GPSMessageFactory(sentinel.buffer)
         self.mock_find_message_class.assert_called_once_with(
-            sentinel.msg, gps_messages.GPSMessage)
+            sentinel.msg, self.mock_GPSMessage)
 
     def test_factory_return_none_if_no_message(self):
         self.mock_GPSMessage.extract_message_from_buffer.return_value = \
@@ -180,6 +180,18 @@ class GPSMessageFactoryTest(unittest.TestCase):
         actual = gps_messages.GPSMessageFactory(sentinel.buffer)
 
         self.assertIsNone(actual)
+
+    @patch.object(gps_messages, 'logger', autospec=True)
+    def test_factory_catches_CorruptMessageError(self, mock_logger):
+        corrupt_message_error = gps_messages.CorruptMessageError()
+        mock_Class = Mock()
+        mock_Class.side_effect = corrupt_message_error
+        self.mock_find_message_class.return_value = mock_Class
+
+        actual = gps_messages.GPSMessageFactory(sentinel.buffer)
+
+        self.assertIsNone(actual)
+        mock_logger.error.assert_called_once_with(corrupt_message_error)
 
 
 class FindMessageForTest(unittest.TestCase):

--- a/pysparc/tests/test_gps_messages.py
+++ b/pysparc/tests/test_gps_messages.py
@@ -51,6 +51,10 @@ class GPSMessageTest(unittest.TestCase):
         self.assertEqual(func(bytearray('baz')),
                          None)
 
+        # incomplete message, no stop codon
+        self.assertEqual(func(bytearray('\x10foo')),
+                         None)
+
     def test_extract_message_from_buffer_deletes_from_buffer(self):
         buff = bytearray('\x10foo\x10\x03barbaz')
         gps_messages.GPSMessage.extract_message_from_buffer(buff)

--- a/pysparc/tests/test_gps_messages.py
+++ b/pysparc/tests/test_gps_messages.py
@@ -86,6 +86,32 @@ class GPSMessageTest(unittest.TestCase):
         Fake.is_message_for(msg)
         msg.startswith.assert_called_once_with('\xff\xee')
 
+    @patch.object(messages.BaseMessage, 'encode')
+    def test_encode_calls_and_returns_super(self, mock_super):
+        encoded_msg = self.msg.encode()
+        mock_super.assert_called_once_with()
+        self.assertEqual(encoded_msg, mock_super.return_value)
+
+    @patch.object(messages.BaseMessage, 'encode')
+    def test_encode_sets_msg_format(self, mock_super):
+        self.msg.msg_format = ''
+        self.msg.identifier = 0xff
+        self.msg.encode()
+        self.assertEqual(self.msg.msg_format, 'B')
+
+        self.msg.msg_format = ''
+        self.msg.identifier = 0x100
+        self.msg.encode()
+        self.assertEqual(self.msg.msg_format, 'H')
+
+    def test_encode_acceptance(self):
+        class FakeMsg(gps_messages.GPSMessage):
+            identifier = 0x1234
+
+        f = FakeMsg()
+        encoded_msg = f.encode()
+        self.assertEqual(encoded_msg, '\x10\x12\x34\x10\x03')
+
 
 class GPSMessageFactoryTest(unittest.TestCase):
 

--- a/pysparc/tests/test_gps_messages.py
+++ b/pysparc/tests/test_gps_messages.py
@@ -117,6 +117,21 @@ class GPSMessageTest(unittest.TestCase):
         self.assertEqual(encoded_msg, '\x10\x12\x34\x10\x03')
 
 
+class UnpackMessagesTest(unittest.TestCase):
+
+    def test_primary_timing_packet(self):
+        self.assertRaises(gps_messages.CorruptMessageError,
+                          gps_messages.PrimaryTimingPacket, 'msg')
+
+    def test_supplemental_timing_packet(self):
+        self.assertRaises(gps_messages.CorruptMessageError,
+                          gps_messages.SupplementalTimingPacket, 'msg')
+
+    def test_software_version_message(self):
+        self.assertRaises(gps_messages.CorruptMessageError,
+                          gps_messages.SoftwareVersionMessage, 'msg')
+
+
 class GPSMessageFactoryTest(unittest.TestCase):
 
     def setUp(self):

--- a/scripts/test_gps.py
+++ b/scripts/test_gps.py
@@ -30,9 +30,10 @@ class Main(object):
         try:
             while True:
                 if time.time() - t0 > 5 and has_reset is False:
-                    msg = gps_messages.ResetMessage('warm')
+                    msg = gps_messages.ResetMessage('factory')
                     self.gps.send_message(msg)
-                    msg = gps_messages.SetSurveyParameters(60)
+                    time.sleep(2.2)
+                    msg = gps_messages.SetSurveyParameters(86400)
                     self.gps.send_message(msg)
                     has_reset = True
 

--- a/scripts/test_gps.py
+++ b/scripts/test_gps.py
@@ -1,7 +1,9 @@
 import logging
+import time
 
 from pysparc.hardware import HiSPARCII, HiSPARCIII, TrimbleGPS
 from pysparc.ftdi_chip import DeviceNotFoundError
+from pysparc import gps_messages
 
 
 class Main(object):
@@ -18,12 +20,30 @@ class Main(object):
         self.device.close()
 
     def run(self):
+        t0 = time.time()
+        has_reset = False
+
+        # msg = gps_messages.ResetMessage(reset_mode='warm')
+        msg = gps_messages.SetInitialPosition(52, 4, 0)
+        self.gps.send_message(msg)
+
         try:
             while True:
+                if time.time() - t0 > 5 and has_reset is False:
+                    msg = gps_messages.ResetMessage('factory')
+                    self.gps.send_message(msg)
+                    msg = gps_messages.SetSurveyParameters(60)
+                    self.gps.send_message(msg)
+                    has_reset = True
+
                 msg = self.gps.read_message()
                 if msg:
                     print msg
-
+                if type(msg) == gps_messages.SupplementalTimingPacket:
+                    print "Survey status: %d%%" % msg.survey_progress
+                    print "Lat: %f, Lon: %f, Alt: %f" % (msg.latitude,
+                                                         msg.longitude,
+                                                         msg.altitude)
         except KeyboardInterrupt:
             logging.info("Keyboard interrupt, shutting down.")
 

--- a/scripts/test_gps.py
+++ b/scripts/test_gps.py
@@ -21,7 +21,7 @@ class Main(object):
         self.gps.close()
 
     def run(self):
-        t0 = time.time()
+        t0 = t1 = time.time()
         has_reset = False
 
         # msg = gps_messages.ResetMessage(reset_mode='warm')
@@ -30,13 +30,17 @@ class Main(object):
 
         try:
             while True:
-                # if time.time() - t0 > 5 and has_reset is False:
-                #     msg = gps_messages.ResetMessage('factory')
-                #     self.gps.send_message(msg)
-                #     time.sleep(2.2)
-                #     msg = gps_messages.SetSurveyParameters(86400)
-                #     self.gps.send_message(msg)
-                #     has_reset = True
+                if time.time() - t1 > 1:
+                    t1 = time.time()
+                    self.gps._device.write('\x10\xbb\x00\x10\x03')
+
+                if time.time() - t0 > 5 and has_reset is False:
+                    msg = gps_messages.ResetMessage('factory')
+                    self.gps.send_message(msg)
+                    time.sleep(2.2)
+                    msg = gps_messages.SetSurveyParameters(10)
+                    self.gps.send_message(msg)
+                    has_reset = True
 
                 msg = self.gps.read_message()
                 if msg:

--- a/scripts/test_gps.py
+++ b/scripts/test_gps.py
@@ -38,7 +38,7 @@ class Main(object):
                     msg = gps_messages.ResetMessage('factory')
                     self.gps.send_message(msg)
                     time.sleep(2.2)
-                    msg = gps_messages.SetSurveyParameters(10)
+                    msg = gps_messages.SetSurveyParameters(86400)
                     self.gps.send_message(msg)
                     has_reset = True
 

--- a/scripts/test_gps.py
+++ b/scripts/test_gps.py
@@ -9,15 +9,16 @@ from pysparc import gps_messages
 class Main(object):
 
     def __init__(self):
-        try:
-            self.device = HiSPARCIII()
-        except DeviceNotFoundError:
-            self.device = HiSPARCII()
+        # try:
+        #     self.device = HiSPARCIII()
+        # except DeviceNotFoundError:
+        #     self.device = HiSPARCII()
         self.gps = TrimbleGPS()
 
     def close(self):
         logging.info("Closing down")
-        self.device.close()
+        # self.device.close()
+        self.gps.close()
 
     def run(self):
         t0 = time.time()
@@ -29,13 +30,13 @@ class Main(object):
 
         try:
             while True:
-                if time.time() - t0 > 5 and has_reset is False:
-                    msg = gps_messages.ResetMessage('factory')
-                    self.gps.send_message(msg)
-                    time.sleep(2.2)
-                    msg = gps_messages.SetSurveyParameters(86400)
-                    self.gps.send_message(msg)
-                    has_reset = True
+                # if time.time() - t0 > 5 and has_reset is False:
+                #     msg = gps_messages.ResetMessage('factory')
+                #     self.gps.send_message(msg)
+                #     time.sleep(2.2)
+                #     msg = gps_messages.SetSurveyParameters(86400)
+                #     self.gps.send_message(msg)
+                #     has_reset = True
 
                 msg = self.gps.read_message()
                 if msg:

--- a/scripts/test_gps.py
+++ b/scripts/test_gps.py
@@ -24,13 +24,13 @@ class Main(object):
         has_reset = False
 
         # msg = gps_messages.ResetMessage(reset_mode='warm')
-        msg = gps_messages.SetInitialPosition(52, 4, 0)
-        self.gps.send_message(msg)
+        # msg = gps_messages.SetInitialPosition(52, 4, 0)
+        # self.gps.send_message(msg)
 
         try:
             while True:
                 if time.time() - t0 > 5 and has_reset is False:
-                    msg = gps_messages.ResetMessage('factory')
+                    msg = gps_messages.ResetMessage('warm')
                     self.gps.send_message(msg)
                     msg = gps_messages.SetSurveyParameters(60)
                     self.gps.send_message(msg)


### PR DESCRIPTION
Configure the GPS receiver.
- [x] force reset to factory defaults on very first startup
- [x] write default values like 86400 survey length
  - [x] survey mode (86400 fixes)
- [x] check all Trimble defaults against HiSPARC documented defaults
- [x] overdetermined clock and stationary?
- [ ] ~~packet output: auto event packets? (Need this for automatic satellite info etc.)~~
- [ ] ~~send GPS configuration events to datastore~~ (move to new PR)

I currently think it is not worth it to create a full-blown config object for the GPS device. There is not much to configure. A few methods on the GPS class, sending messages and maybe receiving replies, should be enough.