### PR TITLE
Split out upgrade as playbook

### DIFF
--- a/provisioning/common.yml
+++ b/provisioning/common.yml
@@ -39,24 +39,6 @@
   apt: update_cache=yes
   sudo: yes
 
-- name: Install update-notifier-common
-  apt: name=screen state=present
-  sudo: yes
-
-- name: Safe-upgrade packages
-  apt: upgrade=safe
-  sudo: yes
-
-- name: Check if reboot is necessary
-  stat: path=/var/run/reboot-required
-  register: p
-
-# if path p is a regular file, trigger reboot
-- name: Flag a reboot if necessary
-  debug: msg="Reboot is necessary"
-  when: p.stat.isreg is defined
-  notify: reboot
-
 - name: Install screen
   apt: name=screen state=present
   sudo: yes

--- a/provisioning/handlers.yml
+++ b/provisioning/handlers.yml
@@ -22,3 +22,4 @@
 
 - name: restart pysparc
   supervisorctl: name=pysparc state=restarted
+  when: inventory_hostname != "vagrant"

--- a/provisioning/prerequisites.yml
+++ b/provisioning/prerequisites.yml
@@ -16,7 +16,7 @@
   pip: name={{ item }} state=present
   sudo: yes
   with_items:
-    - mock
+    - mock==1.1.0
     - pylibftdi
     - atom
     - lazy

--- a/provisioning/pysparc.yml
+++ b/provisioning/pysparc.yml
@@ -32,3 +32,7 @@
   sudo: yes
   notify: restart pysparc
   tags: pysparc
+
+- name: ensure pysparc is running
+  supervisorctl: name=pysparc state=started
+  tags: pysparc

--- a/provisioning/pysparc.yml
+++ b/provisioning/pysparc.yml
@@ -35,4 +35,5 @@
 
 - name: ensure pysparc is running
   supervisorctl: name=pysparc state=started
+  when: inventory_hostname != "vagrant"
   tags: pysparc

--- a/provisioning/upgrade.yml
+++ b/provisioning/upgrade.yml
@@ -38,6 +38,7 @@
     - name: ensure pysparc is started
       supervisorctl: name=pysparc state=started
       when: p.stat.isreg is not defined
+      when: inventory_hostname != "vagrant"
 
   handlers:
     - include: handlers.yml

--- a/provisioning/upgrade.yml
+++ b/provisioning/upgrade.yml
@@ -1,0 +1,43 @@
+---
+- hosts: all
+  tasks:
+    - name: Update package index
+      apt: update_cache=yes
+      sudo: yes
+
+    - name: Install update-notifier-common
+      apt: name=screen state=present
+      sudo: yes
+
+    - name: ensure pysparc is stopped
+      supervisorctl: name=pysparc state=stopped
+
+    - name: ensure redis-server is stopped
+      service: name=redis-server state=stopped
+      sudo: yes
+
+    - name: Safe-upgrade packages
+      apt: upgrade=safe
+      sudo: yes
+
+    - name: Check if reboot is necessary
+      stat: path=/var/run/reboot-required
+      register: p
+
+    # if path p is a regular file, trigger reboot
+    - name: Flag a reboot if necessary
+      debug: msg="Reboot is necessary"
+      when: p.stat.isreg is defined
+      notify: reboot
+
+    - name: ensure redis-server is started
+      service: name=redis-server state=started
+      when: p.stat.isreg is not defined
+      sudo: yes
+
+    - name: ensure pysparc is started
+      supervisorctl: name=pysparc state=started
+      when: p.stat.isreg is not defined
+
+  handlers:
+    - include: handlers.yml


### PR DESCRIPTION
Updating the low-memory Raspberry Pi’s brings the risk of invoking the OOM killer when Redis and PySPARC are running. Make sure they are *not* running.