### PR TITLE
Fix timestamp

### DIFF
--- a/pysparc/events.py
+++ b/pysparc/events.py
@@ -121,10 +121,12 @@ class Stew(object):
         t2_msg = self._get_one_second_message(msg.timestamp + 2)
 
         CTD = msg.count_ticks_PPS
-        CTP = t1_msg.count_ticks_PPS
+        # CTP is everything EXCEPT the synchronization bit
+        CTP = t1_msg.count_ticks_PPS ^ SYNCHRONIZATION_BIT
         synchronization_error = 2.5 if (t0_msg.count_ticks_PPS & SYNCHRONIZATION_BIT) else 0
-        quantization_error1 = t1_msg.quantization_error * 1e9
-        quantization_error2 = t2_msg.quantization_error * 1e9
+        # ERROR IN TRIMBLE/HISPARC DOCS: quantization error is in NANOseconds
+        quantization_error1 = t1_msg.quantization_error
+        quantization_error2 = t2_msg.quantization_error
 
         # This may be larger than one second due to synchronization error!
         trigger_offset = int(synchronization_error + quantization_error1

--- a/scripts/test_timestamp.py
+++ b/scripts/test_timestamp.py
@@ -1,0 +1,12 @@
+import pysparc.hardware
+from pysparc import messages
+
+if 'dev' not in globals():
+    dev = pysparc.hardware.HiSPARCIII()
+    dev.reset_hardware()
+
+dev.config.one_second_enabled = True
+while True:
+    msg = dev.read_message()
+    if (isinstance(msg, messages.OneSecondMessage)):
+        print msg.timestamp, msg.count_ticks_PPS, msg.quantization_error

--- a/scripts/test_timestamp_gps.py
+++ b/scripts/test_timestamp_gps.py
@@ -1,0 +1,10 @@
+import pysparc.hardware
+from pysparc import gps_messages
+
+if 'dev' not in globals():
+    dev = pysparc.hardware.TrimbleGPS()
+
+while True:
+    msg = dev.read_message()
+    if (isinstance(msg, gps_messages.SupplementalTimingPacket)):
+        print msg.pps_quantization_error


### PR DESCRIPTION
Ignore the synchronization bit in the CTP, and there is an error in the
docs. The quantization error is in nanoseconds, not seconds. Sigh.