### PR TITLE
Update std_dev to use same units as LabView DAQ

### DIFF
--- a/pysparc/events.py
+++ b/pysparc/events.py
@@ -246,7 +246,7 @@ class Event(object):
         self.baselines = baselines + [-1, -1]
 
         # Standard deviation of the first 100 samples of the trace
-        std_dev = [int(round(t[:100].std())) for t in self.trace_ch1, self.trace_ch2]
+        std_dev = [int(round(1000 * t[:100].std())) for t in self.trace_ch1, self.trace_ch2]
         self.std_dev = std_dev + [-1, -1]
 
         # Maximum peak to baseline value in trace


### PR DESCRIPTION
Make std_dev units of milli ADC counts, to match the output from the HiSPARC DAQ (LabView):
https://github.com/jorianvo/HISPARC_baseline/blob/master/project/Baseline/src/intern.c#L164-L167

PySPARC stddev is typically 1-2 ADC counts, while for the HiSPARC DAQ typical values are 600-1300 milli ADC counts. Maybe we do not need that many digits for the stddev but for consistency it would be better to keep the units the same.