### PR TITLE
Update upload url to Utah

### DIFF
--- a/pysparc/storage.py
+++ b/pysparc/storage.py
@@ -45,7 +45,7 @@ import pysparc.events
 logger = logging.getLogger(__name__)
 
 
-DATASTORE_URL = "http://frome.nikhef.nl/hisparc/upload"
+DATASTORE_URL = "http://hisparc-raw.chpc.utah.edu/hisparc/upload"
 SLEEP_INTERVAL = .4
 
 


### PR DESCRIPTION
However, we can decide to use something like `upload.hisparc.nl` or `raw.hisparc.nl`.

Related: https://github.com/HiSPARC/station-software/pull/56